### PR TITLE
Added check to ensure macros property exists, otherwise continue the …

### DIFF
--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -56,7 +56,11 @@ class MacrosCommand extends Command
 
         foreach ($classes as $class) {
             $reflection = new \ReflectionClass($class);
-            $property = $reflection->getProperty('macros');
+            if ($reflection->hasProperty('macros')) {
+                $property = $reflection->getProperty('macros');
+            } else {
+                continue;
+            }
             $property->setAccessible(true);
             $macros = $property->getValue();
 


### PR DESCRIPTION
For classes without a macro property, an error of:

> [ReflectionException]
>  Property macros does not exist

was occurring. I've added a check for the macros property, if the property doesn't exist, the loop skips to the next iteration. 