### PR TITLE
Parsing support for class+method callable and added --filename option

### DIFF
--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -89,7 +89,13 @@ class MacrosCommand extends Command
             $this->generateNamespace($reflection->getNamespaceName(), function () use ($macros, $reflection) {
                 $this->generateClass($reflection->getShortName(), function () use ($macros) {
                     foreach ($macros as $name => $macro) {
-                        $function = new \ReflectionFunction($macro);
+                        if(is_array($macro)) {
+                            list($class, $method) = $macro;
+                            $function = new \ReflectionMethod(is_object($class) ? get_class($class) : $class, $method);
+                        } else {
+                            $function = new \ReflectionFunction($macro);
+                        }
+
                         if ($comment = $function->getDocComment()) {
                             $this->writeLine($comment, $this->indent);
 

--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -7,7 +7,7 @@ use Illuminate\Console\Command;
 class MacrosCommand extends Command
 {
     /** @var string The name and signature of the console command */
-    protected $signature = 'ide-helper:macros';
+    protected $signature = 'ide-helper:macros {--filename=}';
 
     /** @var string The console command description */
     protected $description = 'Generate an IDE helper file for Laravel macros';
@@ -60,7 +60,7 @@ class MacrosCommand extends Command
     {
         $classes = array_merge($this->classes, config('ide-macros.classes', []));
 
-        $fileName = config('ide-macros.filename');
+        $fileName = $this->option('filename') ?: config('ide-macros.filename');
         $this->file = fopen(base_path($fileName), 'w');
         $this->writeLine("<?php");
 


### PR DESCRIPTION
Laravel suggest to add macros using service providers. If you create the macro using a closure or a funcion the helper works well but fails if you use a *callable* with an array of class+method the helper thows an exception: 

```
In MacrosCommand.php line 98:

Symfony\Component\Debug\Exception\FatalThrowableError]                                      
Type error: ReflectionFunction::__construct() expects parameter 1 to be string, array given
```

Example code:

```php
<?php

namespace App\Providers;

use Illuminate\Support\Collection;
use Illuminate\Support\ServiceProvider;

class CollectionServiceProvider extends ServiceProvider
{
    public function register()
    {
        Collection::macro('test1', [$this, 'test1']);
        Collection::macro('test2', [static::class, 'test2']);
    }

    /**
     * Test
     *
     * @return int
     */
    public function test1()
    {
        return time();
    }

    /**
     * Static test
     *
     * @return int
     */
    public static function test2()
    {
        return time();
    }
}
```

This makes the code more readable, so this PR fixes the exception thrown by the helper trying parse this behaviour.

I also added the `--filename=` option to command (like Laravel IDE Helper) that allows users to change the filename and path without publishing any additional config file (perfect for composer scripts).

Thanks @KristofMorva