### PR TITLE
Add support for variadic parameters

### DIFF
--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -165,9 +165,13 @@ class MacrosCommand extends Command
             if ($index) {
                 $this->write(", ");
             }
+            
+            if ($parameter->isVariadic()) {
+                $this->write('...');
+            }
 
             $this->write("$" . $parameter->getName());
-            if ($parameter->isOptional()) {
+            if ($parameter->isOptional() && !$parameter->isVariadic()) {
                 $this->write(" = " . var_export($parameter->getDefaultValue(), true));
             }
 


### PR DESCRIPTION
This package currently does not support variadic parameters like `validate($rules, ...$params)` — this adds that support.