### PR TITLE
Add type hinting and return types

### DIFF
--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -182,7 +182,7 @@ class MacrosCommand extends Command
 
         $this->write(")");
         if ($returnType) {
-            $this->write(": " . $returnType);
+            $this->write(": $returnType");
         }
         $this->writeLine(" {");
 

--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -161,9 +161,14 @@ class MacrosCommand extends Command
         $this->write(($type ? "$type " : '') . "function $name(", $this->indent);
 
         $index = 0;
+        /* @var $parameters \ReflectionParameter[] */
         foreach ($parameters as $parameter) {
             if ($index) {
                 $this->write(", ");
+            }
+
+            if ($parameter->hasType()) {
+                $this->write($parameter->getType() . " ");
             }
 
             $this->write("$" . $parameter->getName());

--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -152,7 +152,7 @@ class MacrosCommand extends Command
 
     /**
      * @param string $name
-     * @param array $parameters
+     * @param \ReflectionParameter[] $parameters
      * @param string $type
      * @param null|string $returnType
      * @param null|Callable $callback
@@ -163,7 +163,6 @@ class MacrosCommand extends Command
         $this->write(($type ? "$type " : '') . "function $name(", $this->indent);
 
         $index = 0;
-        /* @var $parameters \ReflectionParameter[] */
         foreach ($parameters as $parameter) {
             if ($index) {
                 $this->write(", ");

--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -100,12 +100,12 @@ class MacrosCommand extends Command
                             $this->writeLine($comment, $this->indent);
 
                             if (strpos($comment, '@instantiated') !== false) {
-                                $this->generateFunction($name, $function->getParameters(), "public");
+                                $this->generateFunction($name, $function->getParameters(), "public", $function->getReturnType());
                                 continue;
                             }
                         }
 
-                        $this->generateFunction($name, $function->getParameters(), "public static");
+                        $this->generateFunction($name, $function->getParameters(), "public static", $function->getReturnType());
                     }
                 });
             });
@@ -154,9 +154,11 @@ class MacrosCommand extends Command
      * @param string $name
      * @param array $parameters
      * @param string $type
+     * @param null|string $returnType
      * @param null|Callable $callback
+     * @throws \ReflectionException
      */
-    protected function generateFunction($name, $parameters, $type = '', $callback = null)
+    protected function generateFunction($name, $parameters, $type = '', $returnType = null, $callback = null)
     {
         $this->write(($type ? "$type " : '') . "function $name(", $this->indent);
 
@@ -179,7 +181,11 @@ class MacrosCommand extends Command
             $index++;
         }
 
-        $this->writeLine(") {");
+        $this->write(")");
+        if ($returnType) {
+            $this->write(": " . $returnType);
+        }
+        $this->writeLine(" {");
 
         if ($callback) {
             $callback();


### PR DESCRIPTION
This PR adds return types and parameter types.

Macros like this will now generate the correct ide file
```php
Str::macro('isLength', function (string $str, int $length): bool {
    return static::length($str) == $length;
});
```

This will now generate:
```php
namespace Illuminate\Support {
    class Str {
        public static function isLength(string $str, int $length): bool {

        }
    }
}
```