### PR TITLE
Make the return types absolute if it's a class

### DIFF
--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -97,17 +97,19 @@ class MacrosCommand extends Command
                         } else {
                             $function = new \ReflectionMethod(is_object($macro) ? get_class($macro) : $class, '__invoke');
                         }
+                        
+                        $returnType = $function->getReturnType() ? "\\" . $function->getReturnType() : '';
 
                         if ($comment = $function->getDocComment()) {
                             $this->writeLine($comment, $this->indent);
 
                             if (strpos($comment, '@instantiated') !== false) {
-                                $this->generateFunction($name, $function->getParameters(), "public", $function->getReturnType());
+                                $this->generateFunction($name, $function->getParameters(), "public", $returnType);
                                 continue;
                             }
                         }
 
-                        $this->generateFunction($name, $function->getParameters(), "public static", $function->getReturnType());
+                        $this->generateFunction($name, $function->getParameters(), "public static", $returnType);
                     }
                 });
             });

--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -98,7 +98,8 @@ class MacrosCommand extends Command
                             $function = new \ReflectionMethod(is_object($macro) ? get_class($macro) : $class, '__invoke');
                         }
                         
-                        $returnType = $function->getReturnType() ? "\\" . $function->getReturnType() : '';
+                        $returnType = $function->getReturnType();
+                        $returnType = class_exists($returnType) ? "\\" . $returnType : $returnType;
 
                         if ($comment = $function->getDocComment()) {
                             $this->writeLine($comment, $this->indent);

--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -181,6 +181,10 @@ class MacrosCommand extends Command
             }
 
             if ($parameter->hasType()) {
+                if (!$parameter->getType()->isBuiltin()) {
+                    $this->write("\\");
+                }
+                
                 $this->write($parameter->getType() . " ");
             }
 

--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -98,8 +98,11 @@ class MacrosCommand extends Command
                             $function = new \ReflectionMethod(is_object($macro) ? get_class($macro) : $class, '__invoke');
                         }
                         
-                        $returnType = $function->getReturnType();
-                        $returnType = class_exists($returnType) ? "\\" . $returnType : $returnType;
+                        $returnType = (string) $function->getReturnType();
+
+                        if ($function->getReturnType() && !$function->getReturnType()->isBuiltin()) {
+                            $returnType = "\\$returnType";
+                        }
 
                         if ($comment = $function->getDocComment()) {
                             $this->writeLine($comment, $this->indent);


### PR DESCRIPTION
Hi @KristofMorva 
Thanks you for the great work. I had this problem of return types where relative and not resolved properly inside the namespace.

```php
namespace Illuminate\Foundation\Testing {
    class TestResponse {
        public static function assertJsonContainsModels(string $path, $models): Illuminate\Foundation\Testing\TestResponse {
        }
    }
}
```

I make the return type to be always absolute, which should help with that problem.