### PR TITLE
Fix deprecated reflection type to string

### DIFF
--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -124,7 +124,7 @@ class MacrosCommand extends Command
      */
     protected function generateNamespace($name, $callback = null)
     {
-        $this->writeLine("namespace " . $name . " {", $this->indent);
+        $this->writeLine("\nnamespace " . $name . " {", $this->indent);
 
         if ($callback) {
             $this->indent++;

--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -169,13 +169,20 @@ class MacrosCommand extends Command
             if ($index) {
                 $this->write(", ");
             }
-            
+
             if ($parameter->isVariadic()) {
                 $this->write('...');
             }
 
             if ($parameter->hasType()) {
-                $this->write($parameter->getType() . " ");
+                if (version_compare(PHP_VERSION, '7.1', '<')) {
+                    $this->write($parameter->getType() . " ");
+                } else {
+                    $paramType = $parameter->getType();
+                    if ($paramType instanceof \ReflectionNamedType) {
+                        $this->write($paramType->getName() . " ");
+                    }
+                }
             }
 
             $this->write("$" . $parameter->getName());
@@ -187,8 +194,12 @@ class MacrosCommand extends Command
         }
 
         $this->write(")");
-        if ($returnType) {
-            $this->write(": $returnType");
+        if (version_compare(PHP_VERSION, '7.1', '<')) {
+            if ($returnType) {
+                $this->write(": $returnType");
+            }
+        } elseif ($returnType instanceof \ReflectionNamedType){
+            $this->write(": {$returnType->getName()}");
         }
         $this->writeLine(" {");
 

--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -198,8 +198,8 @@ class MacrosCommand extends Command
             if ($returnType) {
                 $this->write(": \\$returnType");
             }
-        } elseif ($returnType instanceof \ReflectionNamedType){
-            $this->write(": \\{$returnType->getName()}");
+        } elseif ($returnType instanceof \ReflectionNamedType) {
+            $this->write(": \\" . $returnType->getName());
         }
         $this->writeLine(" {");
 

--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -196,10 +196,10 @@ class MacrosCommand extends Command
         $this->write(")");
         if (version_compare(PHP_VERSION, '7.1', '<')) {
             if ($returnType) {
-                $this->write(": $returnType");
+                $this->write(": \\$returnType");
             }
         } elseif ($returnType instanceof \ReflectionNamedType){
-            $this->write(": {$returnType->getName()}");
+            $this->write(": \\{$returnType->getName()}");
         }
         $this->writeLine(" {");
 


### PR DESCRIPTION
`\ReflectionType::__toString()` [was deprecated](https://www.php.net/manual/en/reflectionparameter.gettype.php) in PHP 7.1.

This PR fixes the issue by using `\ReflectionNamedType` when the PHP version is >= 7.1.

I've also included a couple of commits with coding standard fixes that are not related to this issue.