### PR TITLE
Don't throw if macro is not recognizable

### DIFF
--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -3,6 +3,7 @@
 namespace Tutorigo\LaravelMacroHelper\Console;
 
 use Illuminate\Console\Command;
+use ReflectionException;
 
 class MacrosCommand extends Command
 {
@@ -95,7 +96,11 @@ class MacrosCommand extends Command
                         } else if ($macro instanceof \Closure) {
                             $function = new \ReflectionFunction($macro);
                         } else {
-                            $function = new \ReflectionMethod(is_object($macro) ? get_class($macro) : $class, '__invoke');
+                            try {
+                                $function = new \ReflectionMethod(is_object($macro) ? get_class($macro) : $class, '__invoke');
+                            } catch (ReflectionException $e) {
+                                continue;
+                            }
                         }
 
                         if ($comment = $function->getDocComment()) {


### PR DESCRIPTION
Currently, if a macro is registered improperly or in a format that this package doesn't recognize, it throws an exception.  e.g.
```
ReflectionException: Method Illuminate\Support\Carbon::__invoke() does not exist
```
This simply ignores the error and continues.