### PR TITLE
Only add backslash when return type is an object

### DIFF
--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -180,6 +180,9 @@ class MacrosCommand extends Command
                 } else {
                     $paramType = $parameter->getType();
                     if ($paramType instanceof \ReflectionNamedType) {
+                        if ($paramType->allowsNull()) {
+                            $this->write("?");
+                        }
                         $this->write($paramType->getName() . " ");
                     }
                 }
@@ -203,11 +206,14 @@ class MacrosCommand extends Command
                 }
             }
         } elseif ($returnType instanceof \ReflectionNamedType) {
-            if (class_exists($returnType->getName())) {
-                $this->write(": \\" . $returnType->getName());
-            } else {
-                $this->write(": " . $returnType->getName());
+            $this->write(": ");
+            if ($returnType->allowsNull()) {
+                $this->write("?");
             }
+            if (class_exists($returnType->getName())) {
+                $this->write("\\");
+            }
+            $this->write($returnType->getName());
         }
         $this->writeLine(" {");
 

--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -196,10 +196,18 @@ class MacrosCommand extends Command
         $this->write(")");
         if (version_compare(PHP_VERSION, '7.1', '<')) {
             if ($returnType) {
-                $this->write(": \\$returnType");
+                if (class_exists($returnType)) {
+                    $this->write(": \\$returnType");
+                } else {
+                    $this->write(": $returnType");
+                }
             }
         } elseif ($returnType instanceof \ReflectionNamedType) {
-            $this->write(": \\" . $returnType->getName());
+            if (class_exists($returnType->getName())) {
+                $this->write(": \\" . $returnType->getName());
+            } else {
+                $this->write(": " . $returnType->getName());
+            }
         }
         $this->writeLine(" {");
 


### PR DESCRIPTION
Sorry about this. This should fix it.