### PR TITLE
Show where macro came from

### DIFF
--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -66,15 +66,15 @@ class MacrosCommand extends Command
         $this->writeLine("<?php");
 
         foreach ($classes as $class) {
-            if (!class_exists($class)) {
+            if (! class_exists($class)) {
                 continue;
             }
 
             $reflection = new \ReflectionClass($class);
             $propertyName = 'macros';
-            if (!$reflection->hasProperty($propertyName)) {
+            if (! $reflection->hasProperty($propertyName)) {
                 $propertyName = 'globalMacros';
-                if (!$reflection->hasProperty($propertyName)) {
+                if (! $reflection->hasProperty($propertyName)) {
                     continue;
                 }
             }
@@ -83,7 +83,7 @@ class MacrosCommand extends Command
             $property->setAccessible(true);
             $macros = $property->getValue();
 
-            if (!$macros) {
+            if (! $macros) {
                 continue;
             }
 
@@ -93,7 +93,7 @@ class MacrosCommand extends Command
                         if (is_array($macro)) {
                             list($class, $method) = $macro;
                             $function = new \ReflectionMethod(is_object($class) ? get_class($class) : $class, $method);
-                        } else if ($macro instanceof \Closure) {
+                        } elseif ($macro instanceof \Closure) {
                             $function = new \ReflectionFunction($macro);
                         } else {
                             $function = new \ReflectionMethod(is_object($macro) ? get_class($macro) : $class, '__invoke');
@@ -124,8 +124,8 @@ class MacrosCommand extends Command
     }
 
     /**
-     * @param string $name
-     * @param null|Callable $callback
+     * @param  string $name
+     * @param  null|Callable $callback
      */
     protected function generateNamespace($name, $callback = null)
     {
@@ -141,8 +141,8 @@ class MacrosCommand extends Command
     }
 
     /**
-     * @param string $name
-     * @param null|Callable $callback
+     * @param  string $name
+     * @param  null|Callable $callback
      */
     protected function generateClass($name, $callback = null)
     {
@@ -158,11 +158,12 @@ class MacrosCommand extends Command
     }
 
     /**
-     * @param string $name
-     * @param \ReflectionParameter[] $parameters
-     * @param string $type
-     * @param null|string $returnType
-     * @param null|Callable $callback
+     * @param  string $name
+     * @param  \ReflectionParameter[] $parameters
+     * @param  string $type
+     * @param  null|string $returnType
+     * @param  null|Callable $callback
+     *
      * @throws \ReflectionException
      */
     protected function generateFunction($name, $parameters, $type = '', $returnType = null, $callback = null)
@@ -194,7 +195,7 @@ class MacrosCommand extends Command
             }
 
             $this->write("$" . $parameter->getName());
-            if ($parameter->isOptional() && !$parameter->isVariadic()) {
+            if ($parameter->isOptional() && ! $parameter->isVariadic()) {
                 $this->write(" = " . var_export($parameter->getDefaultValue(), true));
             }
 


### PR DESCRIPTION
For whatever reason, I am not able to make PhpStorm jump to the file & line. So, if you know what syntax I need to make it do that let me know and I will happily implement it. Here's an example of the output:

```php
namespace Illuminate\Support {
    class Collection {
        public static function after($currentItem, $fallback = NULL) {
            // @see: vendor/spatie/laravel-collection-macros/src/Macros/After.php:19
        }
        public static function at($index) {
            // @see: vendor/spatie/laravel-collection-macros/src/Macros/At.php:28
        }
        public static function before($currentItem, $fallback = NULL) {
            // @see: vendor/spatie/laravel-collection-macros/src/Macros/Before.php:19
        }
        public static function chunkBy(Closure $callback, bool $preserveKeys = false): \Illuminate\Support\Collection {
            // @see: vendor/spatie/laravel-collection-macros/src/Macros/ChunkBy.php:17
        }
        public static function collectBy($key, $default = NULL): \Illuminate\Support\Collection {
            // @see: vendor/spatie/laravel-collection-macros/src/Macros/CollectBy.php:21
        }
    }
}
```

P.S. I ran php-cs-fixer (well, PhpStorm did automatically on save...) on the Command file. If you want me to revert the code style changes, I can do that.