### PR TITLE
Add \Illuminate\Http\Request support.

### DIFF
--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -42,6 +42,7 @@ class MacrosCommand extends Command
         '\Illuminate\Http\JsonResponse',
         '\Illuminate\Http\RedirectResponse',
         '\Illuminate\Auth\RequestGuard',
+        '\Illuminate\Http\Request',
         '\Illuminate\Http\Response',
         '\Illuminate\Auth\SessionGuard',
         '\Illuminate\Http\UploadedFile',


### PR DESCRIPTION
The class`\Illuminate\Http\Request` from Laravel is macroable, but not listed in `MacrosCommand::$classes` array.

This PR add `\Illuminate\Http\Request` support.