### PR TITLE
Mixed return type includes null

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "laravel/framework": "^5.0|^6.0|^7.0|^8.0|^9.0"
+        "laravel/framework": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "laravel/framework": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0"
+        "laravel/framework": ">=5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -210,7 +210,7 @@ class MacrosCommand extends Command
             }
         } elseif ($returnType instanceof \ReflectionNamedType) {
             $this->write(": ");
-            if ($returnType->allowsNull()) {
+            if ($returnType->allowsNull() && $returnType->getName() !== 'mixed') {
                 $this->write("?");
             }
             if (class_exists($returnType->getName())) {


### PR DESCRIPTION
This PR prevents appending `?` to nullable return types if the return type is `mixed` because `mixed` already includes null. Appending the `?` causes php-lint to complain. For now, I've just excluded `_ide_macros.php` from php-lint in CI so this is low-impact for me. But it might be helpful to others.

I'm not sure this solution is 100% complete. I haven't read the code carefully enough to see how pipe-joined mixed return types are handled and what would happen if the return type were something like `string|int|null`. Obviously in that case, the `?` should also not be appended. Let me know if you think that's something that I should explore further.

Thanks for the great package! It's made my life a whole lot easier.